### PR TITLE
Better unit tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,7 @@ root = true
 
 [*]
 indent_style = space
-indent_size = 2
+indent_size = 4
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ enrollment/.sass-cache
 package-lock.json
 yarn-error.log
 yarn.lock
+/tests/_reports

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,39 @@
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.3/phpunit.xsd"
+    backupGlobals="true"
+    backupStaticAttributes="false"
+    bootstrap="vendor/autoload.php"
+    cacheTokens="false"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    forceCoversAnnotation="false"
+    processIsolation="false"
+    stopOnError="false"
+    stopOnFailure="false"
+    stopOnIncomplete="false"
+    stopOnSkipped="false"
+    stopOnRisky="false"
+    timeoutForSmallTests="1"
+    timeoutForMediumTests="10"
+    timeoutForLargeTests="60"
+    verbose="false">
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory suffix=".php">./tests</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">./src</directory>
+            <directory suffix=".php">./tests</directory>
+        </whitelist>
+    </filter>
+    <logging>
+        <log type="coverage-clover" target="tests/_reports/logs/clover.xml"/>
+        <log type="coverage-html" target="tests/_reports/coverage" lowUpperBound="35" highLowerBound="70" />
+        <log type="testdox-text" target="tests/_reports/testdox/executed.txt"/>
+    </logging>
+</phpunit>

--- a/tests/TestUrls.php
+++ b/tests/TestUrls.php
@@ -3,14 +3,13 @@
 use PHPUnit\Framework\TestCase;
 use eURL\Functions as url;
 
-require(__DIR__ . "/../vendor/autoload.php");
-
 final class ValidUrls extends TestCase
 {
     /**
      * @dataProvider validUrlProvider
      */
-	public function testValidUrl($url) {
+	public function testValidUrl($url): void
+	{
 
 		$this->assertSame($url, url\e($url));
 
@@ -19,7 +18,8 @@ final class ValidUrls extends TestCase
     /**
      * @dataProvider invalidUrlProvider
      */
-	public function testInvalidUrl($url, $expected) {
+	public function testInvalidUrl($url, $expected): void
+	{
 
 		$this->assertSame($expected, url\e($url));
 
@@ -28,7 +28,7 @@ final class ValidUrls extends TestCase
 	/**
      * @codeCoverageIgnore
      */
-    public function validUrlProvider()
+    public function validUrlProvider(): array
     {
         return [
 
@@ -64,6 +64,28 @@ final class ValidUrls extends TestCase
 			["http://google.com?v1=1%3C2"],
 			["http://google.com?1%3C2=v1"],
 			["http://google.com/1%3C2/?te=12&b="],
+
+			// relative
+			['/relative'],
+			['/relative/test/'],
+			['/relative#fragment'],
+			['/relative/#fragment'],
+			['/relative?q1=v1&q2v2'],
+			['/relative?q1=v1&q2v2='],
+			['/relative/?q1=v1&q2v2'],
+			['/relative/?q1=v1&q2v2='],
+			['/relative/page#fragment'],
+			['/relative/page/#fragment'],
+			['/relative?q1=v1&q2v2=#fragment'],
+			['/relative/?q1=v1&q2v2=#fragment'],
+			['/relative?q1=v1&q2v2#fragment'],
+			['/relative/?q1=v1&q2v2#fragment'],
+			['relative'],
+			['relative/test/'],
+			['relative#fragment'],
+			['relative/#fragment'],
+			['relative?q1=v1&q2v2'],
+			['relative?q1=v1&q2v2='],
 			
 		];
 	}
@@ -71,7 +93,7 @@ final class ValidUrls extends TestCase
 	/**
      * @codeCoverageIgnore
      */
-    public function invalidUrlProvider()
+    public function invalidUrlProvider(): array
     {
 		return [
 
@@ -98,6 +120,13 @@ final class ValidUrls extends TestCase
 			['subdomain.subdomain.google.com?q1=v1&q2v2', 'http://subdomain.subdomain.google.com?q1=v1&q2v2'],
 			['subdomain.subdomain.google.com/?q1=v1&q2v2=#fragment', 'http://subdomain.subdomain.google.com/?q1=v1&q2v2=#fragment'],
 
+			// relative enconding
+			["/relative?v1=1<2", "/relative?v1=1%3C2"],
+			["/relative?1<2=v1", "/relative?1%3C2=v1"],
+			["http://goo>:gle.com?v1=12", ""], //Those chars at the domain level makes the url invalid, therefore the result should be empty.
+			["/relative/1<2/?te=12&b=", "/relative/1%3C2/?te=12&b="],
+			["/relative/1<2/?te=12&b=", "/relative/1%3C2/?te=12&b="],
+
 
 			// XSS
 
@@ -117,88 +146,4 @@ final class ValidUrls extends TestCase
 
 		];
 	}
-
-	/*
-	public function testRelativeUrls(): void
-	{
-	$urls = [
-		"/relative",
-		"/relative/test/",
-		"/relative#fragment",
-		"/relative/#fragment",
-		"/relative?q1=v1&q2v2",
-		"/relative?q1=v1&q2v2=",
-		"/relative/?q1=v1&q2v2",
-		"/relative/?q1=v1&q2v2=",
-		"/relative/page#fragment",
-		"/relative/page/#fragment",
-		"/relative?q1=v1&q2v2=#fragment",
-		"/relative/?q1=v1&q2v2=#fragment",
-		"/relative?q1=v1&q2v2#fragment",
-		"/relative/?q1=v1&q2v2#fragment",
-		"relative",
-		"relative/test/",
-		"relative#fragment",
-		"relative/#fragment",
-		"relative?q1=v1&q2v2",
-		"relative?q1=v1&q2v2=",
-	];
-	$failures = [];
-	foreach ($urls as $url) {
-		try {
-		$this->assertEquals($url, url\e($url), "Failed at url $url");
-		} catch (\Exception $e) {
-		$failures[] = $url . " !== " . url\e($url);
-		}
-	}
-	if (!empty($failures)) {
-		throw new AssertionFailedError (
-		count($failures) . " assertions failed:\n\t" . implode("\n\t", $failures)
-		);
-	}
-	}
-
-	public function testRelativeUrlsEncoding(): void
-	{
-	$urls = [
-		[
-		"toTest" => "/relative?v1=1<2",
-		"expectedResult" => "/relative?v1=1%3C2"
-		],
-		[
-		"toTest" => "/relative?1<2=v1",
-		"expectedResult" => "/relative?1%3C2=v1"
-		],
-		[
-		"toTest" => "http://goo>:gle.com?v1=12",
-		"expectedResult" => "" //Those chars at the domain level makes the url invalid, therefore the result should be empty.
-		],
-		[
-		"toTest" => "/relative/1<2/?te=12&b=",
-		"expectedResult" => "/relative/1%3C2/?te=12&b="
-		],
-		[
-		"toTest" => "/relative/1<2/?te=12&b=",
-		"expectedResult" => "/relative/1%3C2/?te=12&b="
-		]
-	];
-
-	$failures = [];
-	foreach ($urls as $url) {
-		try {
-		$this->assertEquals(
-			$url['expectedResult'],
-			url\e($url['htoTest'] ),
-			"Failed at url " . $url['htoTest'] . " result: " . url\e($url['htoTest']) . " expected: " . $url['expectedResult']
-		);
-		} catch (\Exception $e) {
-		$failures[] = $e->getMessage();
-		}
-	}
-	if (!empty($failures)) {
-		throw new AssertionFailedError (
-		count($failures) . " assertions failed:\n\t" . implode("\n\t", $failures)
-		);
-	}
-	*/
 }

--- a/tests/TestUrls.php
+++ b/tests/TestUrls.php
@@ -7,27 +7,32 @@ require(__DIR__ . "/../vendor/autoload.php");
 
 final class ValidUrls extends TestCase
 {
-	public function urlValidTest($url) {
+    /**
+     * @dataProvider validUrlProvider
+     */
+	public function testValidUrl($url) {
 
 		$this->assertSame($url, url\e($url));
 
 	}
 
     /**
-     * @dataProvider urlProvider
+     * @dataProvider invalidUrlProvider
      */
-	public function testValidSimpleUrls($url) {
+	public function testInvalidUrl($url, $expected) {
 
-		$this->urlValidTest($url);
+		$this->assertSame($expected, url\e($url));
 
 	}
 
 	/**
      * @codeCoverageIgnore
      */
-    public function urlProvider()
+    public function validUrlProvider()
     {
         return [
+
+			// simple urls
 			['http://google.com'],
 			['http://google.com#fragment'],
 			['http://google.com/#fragment'],
@@ -46,162 +51,70 @@ final class ValidUrls extends TestCase
 			['http://google.com/?q1=v1&q2v2=#fragment'],
 			['http://google.com?q1=v1&q2v2#fragment'],
 			['http://google.com/?q1=v1&q2v2#fragment'],
-		];
-	}
-
-    /**
-     * @dataProvider urlSchemeProvider
-     */
-	public function testValidSchemeUrls($url) {
-
-		$this->urlValidTest($url);
-
-	}
-
-	/**
-     * @codeCoverageIgnore
-     */
-    public function urlSchemeProvider()
-    {
-		return [
-			['google.com'],
-			['google.com#fragment'],
-			['google.com/#fragment'],
-			['google.com?q1=v1&q2v2'],
-			['google.com/?q1=v1&q2v2=#fragment'],
-			['subdomain.google.com'],
-			['subdomain.google.com#fragment'],
-			['subdomain.google.com/#fragment'],
-			['subdomain.google.com?q1=v1&q2v2'],
-			['subdomain.google.com/?q1=v1&q2v2=#fragment'],
-			['subdomain.subdomain.google.com'],
-			['subdomain.subdomain.google.com#fragment'],
-			['subdomain.subdomain.google.com/#fragment'],
-			['subdomain.subdomain.google.com?q1=v1&q2v2'],
-			['subdomain.subdomain.google.com/?q1=v1&q2v2=#fragment'],
-		];
-	}
-
-    /**
-     * @dataProvider copyAndPastedUrlsProvider
-     */
-	public function testCopyAndPastedUrlsTest($url) {
-
-		$this->urlValidTest($url);
-
-	}
-
-	/**
-     * @codeCoverageIgnore
-     */
-    public function copyAndPastedUrlsProvider()
-    {
-		return [
+			
+			// copy and pasted
 			['https://stackoverflow.com/questions/2681786/how-to-get-the-last-char-of-a-string-in-php'],
 			['https://www.google.com/search?sxsrf=ACYBGNTJ6_E7vGHuXly-wapQEdX0-WR2eg%3A1571805081701&source=hp&ei=mdevXdCQKL685OUPwY-SqAs&q=test&btnK=Pesquisa+Google&oq=mail+url&gs_l=psy-ab.3..0i203l4j0i22i30l6.48741.49673..50184...0.0..0.98.570.8......0....1..gws-wiz.......35i39j0j0i67j0i10i203.wUQYlQVEwxU&ved=0ahUKEwiQwbGcxrHlAhU-HrkGHcGHBLUQ4dUDCAY&uact=5'],
 			['https://www.google.com/search?q=test&sxsrf=ACYBGNSqRqbaCthrNVueRbiXQlYaA64AxQ1571808636488&source=lnms&tbm=isch&sa=X&ved=0ahUKEwjo6Lq707HlAhUfGbkGHaM1AacQ_AUIEigB&biw=1920&bih=878#imgrc=fZg5jDE2xDewFM'],
 			['https://www.google.com/aclk?sa=L&ai=DChcSEwjA4ZLf07HlAhXECZEKHV5YAOMYABAAGgJjZQ&sig=AOD64_33mdKrF1qaxefqngRdnf_JGHc7Cw&q=&ved=2ahUKEwijgI3f07HlAhWKIbkGHdhuDsUQ0Qx6BAgNEAE&adurl='],
 			['https://www.facebook.com/photo.php?fbid=2272467782784102&set=a.378834528814113&type=3&theater'],
 			['https://www.google.com/search?sxsrf=ACYBGNTJ6_E7vGHuXly-wapQEdX0-WR2eg%3A1571805081701&source=hp&ei=mdevXdCQKL685OUPwY-SqAs&q=t%C3%A9ste+busca+com+acento&btnK=Pesquisa+Google&oq=mail+url&gs_l=psy-ab.3..0i203l4j0i22i30l6.48741.49673..50184...0.0..0.98.570.8......0....1..gws-wiz.......35i39j0j0i67j0i10i203.wUQYlQVEwxU&ved=0ahUKEwiQwbGcxrHlAhU-HrkGHcGHBLUQ4dUDCAY&uact=5'],
-		];
-	}
-
-    /**
-     * @dataProvider urlEncodingProvider
-     */
-	public function testUrlEncoding($url, $expected) {
-
-		$this->assertSame($expected, url\e($url));
-
-	}
-
-	/**
-     * @codeCoverageIgnore
-     */
-    public function urlEncodingProvider()
-    {
-		return [
-
-			["http://google.com?v1=1<2", "http://google.com?v1=1%3C2"],
-			["http://google.com?1<2=v1", "http://google.com?1%3C2=v1"],
-
-			//Those chars at the domain level makes the url invalid, therefore the result should be empty.
-			["http://goo>:gle.com?v1=12", ""],
-
-			["http://google.com/1<2/?te=12&b=", "http://google.com/1%3C2/?te=12&b="],
-			["http://google.com/1<2/?te=12&b=", "http://google.com/1%3C2/?te=12&b="],
-
-		];
-	}
-
-    /**
-     * @dataProvider urlDoubleEncodingProvider
-     */
-	public function testUrlDoubleEncoding($url) {
-
-		$this->urlValidTest($url);
-
-	}
-
-	/**
-     * @codeCoverageIgnore
-     */
-    public function urlDoubleEncodingProvider()
-    {
-		return [
+		
+			// double enconding
 			["http://google.com?v1=1%3C2"],
 			["http://google.com?1%3C2=v1"],
 			["http://google.com/1%3C2/?te=12&b="],
+			
 		];
-	}
-
-    /**
-     * @dataProvider xssAttemptsProvider
-     */
-	public function testXssAttempts($url, $expected) {
-
-		$this->assertSame($expected, url\e($url));
-
 	}
 
 	/**
      * @codeCoverageIgnore
      */
-    public function xssAttemptsProvider()
+    public function invalidUrlProvider()
     {
 		return [
-			[
-				'http://example.com/"><script>alert("xss")</script>',
-				'http://example.com/%22%3E%3Cscript%3Ealert(%22xss%22)%3C/script%3E' //Should escape the path
-			],
-			[
-				"http://example.com/'><script>alert('xss')</script>",
-				"http://example.com/%27%3E%3Cscript%3Ealert(%27xss%27)%3C/script%3E" //Should escape the path
-			],
-			[
-				"javascript://test%0Aalert(321)",
-				'' //Shouldn't accept javascript scheme
-			],
-			[
-				"javascript://alert(1)",
-				'' //Shouldn't accept javascript scheme
-			],
-			[
-				" javascript://alert(1)",
-				'' //Shouldn't accept javascript scheme
-			],
-			[
-				"http://google.com?q1=\"<script>alert(1)</script>",
-				"http://google.com?q1=%22%3Cscript%3Ealert(1)%3C/script%3E", //Should escape the query string
-			],
-			[
-				"http://google.com/\"<script>alert(1)</script>/?q1",
-				"http://google.com/%22%3Cscript%3Ealert(1)%3C/script%3E/?q1",
-			],
-			[
-				"http://google.com/#\"<script>alert(1)</script>/?q1",
-				"http://google.com/#%22%3Cscript%3Ealert(1)%3C/script%3E/?q1",
-			],
+
+			// encoding
+			["http://google.com?v1=1<2", "http://google.com?v1=1%3C2"],
+			["http://google.com?1<2=v1", "http://google.com?1%3C2=v1"],
+			["http://goo>:gle.com?v1=12", ""], //Those chars at the domain level makes the url invalid, therefore the result should be empty.
+			["http://google.com/1<2/?te=12&b=", "http://google.com/1%3C2/?te=12&b="],
+
+			// without scheme
+			['google.com', 'http://google.com'],
+			['google.com#fragment', 'http://google.com#fragment'],
+			['google.com/#fragment', 'http://google.com/#fragment'],
+			['google.com?q1=v1&q2v2', 'http://google.com?q1=v1&q2v2'],
+			['google.com/?q1=v1&q2v2=#fragment', 'http://google.com/?q1=v1&q2v2=#fragment'],
+			['subdomain.google.com', 'http://subdomain.google.com'],
+			['subdomain.google.com#fragment', 'http://subdomain.google.com#fragment'],
+			['subdomain.google.com/#fragment', 'http://subdomain.google.com/#fragment'],
+			['subdomain.google.com?q1=v1&q2v2', 'http://subdomain.google.com?q1=v1&q2v2'],
+			['subdomain.google.com/?q1=v1&q2v2=#fragment', 'http://subdomain.google.com/?q1=v1&q2v2=#fragment'],
+			['subdomain.subdomain.google.com', 'http://subdomain.subdomain.google.com'],
+			['subdomain.subdomain.google.com#fragment', 'http://subdomain.subdomain.google.com#fragment'],
+			['subdomain.subdomain.google.com/#fragment', 'http://subdomain.subdomain.google.com/#fragment'],
+			['subdomain.subdomain.google.com?q1=v1&q2v2', 'http://subdomain.subdomain.google.com?q1=v1&q2v2'],
+			['subdomain.subdomain.google.com/?q1=v1&q2v2=#fragment', 'http://subdomain.subdomain.google.com/?q1=v1&q2v2=#fragment'],
+
+
+			// XSS
+
+			//Should escape the path
+			['http://example.com/"><script>alert("xss")</script>', 'http://example.com/%22%3E%3Cscript%3Ealert(%22xss%22)%3C/script%3E'],
+			["http://example.com/'><script>alert('xss')</script>", "http://example.com/%27%3E%3Cscript%3Ealert(%27xss%27)%3C/script%3E"],
+
+			//Shouldn't accept javascript scheme
+			["javascript://test%0Aalert(321)", ''],
+			["javascript://alert(1)",'' ],
+			[" javascript://alert(1)", ''],
+
+			//Should escape the query string
+			["http://google.com?q1=\"<script>alert(1)</script>", "http://google.com?q1=%22%3Cscript%3Ealert(1)%3C/script%3E"],
+			["http://google.com/\"<script>alert(1)</script>/?q1", "http://google.com/%22%3Cscript%3Ealert(1)%3C/script%3E/?q1"],
+			["http://google.com/#\"<script>alert(1)</script>/?q1", "http://google.com/#%22%3Cscript%3Ealert(1)%3C/script%3E/?q1"],
+
 		];
 	}
 

--- a/tests/TestUrls.php
+++ b/tests/TestUrls.php
@@ -8,138 +8,138 @@ final class ValidUrls extends TestCase
     /**
      * @dataProvider validUrlProvider
      */
-	public function testValidUrl($url): void
-	{
-		$this->assertSame($url, url\e($url));
-	}
+    public function testValidUrl($url): void
+    {
+        $this->assertSame($url, url\e($url));
+    }
 
     /**
      * @dataProvider invalidUrlProvider
      */
-	public function testInvalidUrl($url, $expected): void
-	{
-		$this->assertSame($expected, url\e($url));
-	}
+    public function testInvalidUrl($url, $expected): void
+    {
+        $this->assertSame($expected, url\e($url));
+    }
 
-	/**
+    /**
      * @codeCoverageIgnore
      */
     public function validUrlProvider(): array
     {
         return [
 
-			// simple urls
-			['http://google.com'],
-			['http://google.com#fragment'],
-			['http://google.com/#fragment'],
-			['http://google.com?q1=v1&q2v2'],
-			['http://google.com?q1=v1&q2v2='],
-			['http://google.com/?q1=v1&q2v2'],
-			['http://google.com/?q1=v1&q2v2='],
-			['https://google.com'],
-			['https://google.com#fragment'],
-			['https://google.com/#fragment'],
-			['https://google.com?q1=v1&q2v2'],
-			['https://google.com/?q1=v1&q2v2'],
-			['http://google.com/page#fragment'],
-			['http://google.com/page/#fragment'],
-			['http://google.com?q1=v1&q2v2=#fragment'],
-			['http://google.com/?q1=v1&q2v2=#fragment'],
-			['http://google.com?q1=v1&q2v2#fragment'],
-			['http://google.com/?q1=v1&q2v2#fragment'],
-			
-			// copy and pasted
-			['https://stackoverflow.com/questions/2681786/how-to-get-the-last-char-of-a-string-in-php'],
-			['https://www.google.com/search?sxsrf=ACYBGNTJ6_E7vGHuXly-wapQEdX0-WR2eg%3A1571805081701&source=hp&ei=mdevXdCQKL685OUPwY-SqAs&q=test&btnK=Pesquisa+Google&oq=mail+url&gs_l=psy-ab.3..0i203l4j0i22i30l6.48741.49673..50184...0.0..0.98.570.8......0....1..gws-wiz.......35i39j0j0i67j0i10i203.wUQYlQVEwxU&ved=0ahUKEwiQwbGcxrHlAhU-HrkGHcGHBLUQ4dUDCAY&uact=5'],
-			['https://www.google.com/search?q=test&sxsrf=ACYBGNSqRqbaCthrNVueRbiXQlYaA64AxQ1571808636488&source=lnms&tbm=isch&sa=X&ved=0ahUKEwjo6Lq707HlAhUfGbkGHaM1AacQ_AUIEigB&biw=1920&bih=878#imgrc=fZg5jDE2xDewFM'],
-			['https://www.google.com/aclk?sa=L&ai=DChcSEwjA4ZLf07HlAhXECZEKHV5YAOMYABAAGgJjZQ&sig=AOD64_33mdKrF1qaxefqngRdnf_JGHc7Cw&q=&ved=2ahUKEwijgI3f07HlAhWKIbkGHdhuDsUQ0Qx6BAgNEAE&adurl='],
-			['https://www.facebook.com/photo.php?fbid=2272467782784102&set=a.378834528814113&type=3&theater'],
-			['https://www.google.com/search?sxsrf=ACYBGNTJ6_E7vGHuXly-wapQEdX0-WR2eg%3A1571805081701&source=hp&ei=mdevXdCQKL685OUPwY-SqAs&q=t%C3%A9ste+busca+com+acento&btnK=Pesquisa+Google&oq=mail+url&gs_l=psy-ab.3..0i203l4j0i22i30l6.48741.49673..50184...0.0..0.98.570.8......0....1..gws-wiz.......35i39j0j0i67j0i10i203.wUQYlQVEwxU&ved=0ahUKEwiQwbGcxrHlAhU-HrkGHcGHBLUQ4dUDCAY&uact=5'],
-		
-			// double enconding
-			["http://google.com?v1=1%3C2"],
-			["http://google.com?1%3C2=v1"],
-			["http://google.com/1%3C2/?te=12&b="],
+            // simple urls
+            ['http://google.com'],
+            ['http://google.com#fragment'],
+            ['http://google.com/#fragment'],
+            ['http://google.com?q1=v1&q2v2'],
+            ['http://google.com?q1=v1&q2v2='],
+            ['http://google.com/?q1=v1&q2v2'],
+            ['http://google.com/?q1=v1&q2v2='],
+            ['https://google.com'],
+            ['https://google.com#fragment'],
+            ['https://google.com/#fragment'],
+            ['https://google.com?q1=v1&q2v2'],
+            ['https://google.com/?q1=v1&q2v2'],
+            ['http://google.com/page#fragment'],
+            ['http://google.com/page/#fragment'],
+            ['http://google.com?q1=v1&q2v2=#fragment'],
+            ['http://google.com/?q1=v1&q2v2=#fragment'],
+            ['http://google.com?q1=v1&q2v2#fragment'],
+            ['http://google.com/?q1=v1&q2v2#fragment'],
+            
+            // copy and pasted
+            ['https://stackoverflow.com/questions/2681786/how-to-get-the-last-char-of-a-string-in-php'],
+            ['https://www.google.com/search?sxsrf=ACYBGNTJ6_E7vGHuXly-wapQEdX0-WR2eg%3A1571805081701&source=hp&ei=mdevXdCQKL685OUPwY-SqAs&q=test&btnK=Pesquisa+Google&oq=mail+url&gs_l=psy-ab.3..0i203l4j0i22i30l6.48741.49673..50184...0.0..0.98.570.8......0....1..gws-wiz.......35i39j0j0i67j0i10i203.wUQYlQVEwxU&ved=0ahUKEwiQwbGcxrHlAhU-HrkGHcGHBLUQ4dUDCAY&uact=5'],
+            ['https://www.google.com/search?q=test&sxsrf=ACYBGNSqRqbaCthrNVueRbiXQlYaA64AxQ1571808636488&source=lnms&tbm=isch&sa=X&ved=0ahUKEwjo6Lq707HlAhUfGbkGHaM1AacQ_AUIEigB&biw=1920&bih=878#imgrc=fZg5jDE2xDewFM'],
+            ['https://www.google.com/aclk?sa=L&ai=DChcSEwjA4ZLf07HlAhXECZEKHV5YAOMYABAAGgJjZQ&sig=AOD64_33mdKrF1qaxefqngRdnf_JGHc7Cw&q=&ved=2ahUKEwijgI3f07HlAhWKIbkGHdhuDsUQ0Qx6BAgNEAE&adurl='],
+            ['https://www.facebook.com/photo.php?fbid=2272467782784102&set=a.378834528814113&type=3&theater'],
+            ['https://www.google.com/search?sxsrf=ACYBGNTJ6_E7vGHuXly-wapQEdX0-WR2eg%3A1571805081701&source=hp&ei=mdevXdCQKL685OUPwY-SqAs&q=t%C3%A9ste+busca+com+acento&btnK=Pesquisa+Google&oq=mail+url&gs_l=psy-ab.3..0i203l4j0i22i30l6.48741.49673..50184...0.0..0.98.570.8......0....1..gws-wiz.......35i39j0j0i67j0i10i203.wUQYlQVEwxU&ved=0ahUKEwiQwbGcxrHlAhU-HrkGHcGHBLUQ4dUDCAY&uact=5'],
+        
+            // double enconding
+            ["http://google.com?v1=1%3C2"],
+            ["http://google.com?1%3C2=v1"],
+            ["http://google.com/1%3C2/?te=12&b="],
 
-			// relative
-			['/relative'],
-			['/relative/test/'],
-			['/relative#fragment'],
-			['/relative/#fragment'],
-			['/relative?q1=v1&q2v2'],
-			['/relative?q1=v1&q2v2='],
-			['/relative/?q1=v1&q2v2'],
-			['/relative/?q1=v1&q2v2='],
-			['/relative/page#fragment'],
-			['/relative/page/#fragment'],
-			['/relative?q1=v1&q2v2=#fragment'],
-			['/relative/?q1=v1&q2v2=#fragment'],
-			['/relative?q1=v1&q2v2#fragment'],
-			['/relative/?q1=v1&q2v2#fragment'],
-			['relative'],
-			['relative/test/'],
-			['relative#fragment'],
-			['relative/#fragment'],
-			['relative?q1=v1&q2v2'],
-			['relative?q1=v1&q2v2='],
-			
-		];
-	}
+            // relative
+            ['/relative'],
+            ['/relative/test/'],
+            ['/relative#fragment'],
+            ['/relative/#fragment'],
+            ['/relative?q1=v1&q2v2'],
+            ['/relative?q1=v1&q2v2='],
+            ['/relative/?q1=v1&q2v2'],
+            ['/relative/?q1=v1&q2v2='],
+            ['/relative/page#fragment'],
+            ['/relative/page/#fragment'],
+            ['/relative?q1=v1&q2v2=#fragment'],
+            ['/relative/?q1=v1&q2v2=#fragment'],
+            ['/relative?q1=v1&q2v2#fragment'],
+            ['/relative/?q1=v1&q2v2#fragment'],
+            ['relative'],
+            ['relative/test/'],
+            ['relative#fragment'],
+            ['relative/#fragment'],
+            ['relative?q1=v1&q2v2'],
+            ['relative?q1=v1&q2v2='],
+            
+        ];
+    }
 
-	/**
+    /**
      * @codeCoverageIgnore
      */
     public function invalidUrlProvider(): array
     {
-		return [
+        return [
 
-			// encoding
-			["http://google.com?v1=1<2", "http://google.com?v1=1%3C2"],
-			["http://google.com?1<2=v1", "http://google.com?1%3C2=v1"],
-			["http://goo>:gle.com?v1=12", ""], //Those chars at the domain level makes the url invalid, therefore the result should be empty.
-			["http://google.com/1<2/?te=12&b=", "http://google.com/1%3C2/?te=12&b="],
+            // encoding
+            ["http://google.com?v1=1<2", "http://google.com?v1=1%3C2"],
+            ["http://google.com?1<2=v1", "http://google.com?1%3C2=v1"],
+            ["http://goo>:gle.com?v1=12", ""], //Those chars at the domain level makes the url invalid, therefore the result should be empty.
+            ["http://google.com/1<2/?te=12&b=", "http://google.com/1%3C2/?te=12&b="],
 
-			// without scheme
-			['google.com', 'http://google.com'],
-			['google.com#fragment', 'http://google.com#fragment'],
-			['google.com/#fragment', 'http://google.com/#fragment'],
-			['google.com?q1=v1&q2v2', 'http://google.com?q1=v1&q2v2'],
-			['google.com/?q1=v1&q2v2=#fragment', 'http://google.com/?q1=v1&q2v2=#fragment'],
-			['subdomain.google.com', 'http://subdomain.google.com'],
-			['subdomain.google.com#fragment', 'http://subdomain.google.com#fragment'],
-			['subdomain.google.com/#fragment', 'http://subdomain.google.com/#fragment'],
-			['subdomain.google.com?q1=v1&q2v2', 'http://subdomain.google.com?q1=v1&q2v2'],
-			['subdomain.google.com/?q1=v1&q2v2=#fragment', 'http://subdomain.google.com/?q1=v1&q2v2=#fragment'],
-			['subdomain.subdomain.google.com', 'http://subdomain.subdomain.google.com'],
-			['subdomain.subdomain.google.com#fragment', 'http://subdomain.subdomain.google.com#fragment'],
-			['subdomain.subdomain.google.com/#fragment', 'http://subdomain.subdomain.google.com/#fragment'],
-			['subdomain.subdomain.google.com?q1=v1&q2v2', 'http://subdomain.subdomain.google.com?q1=v1&q2v2'],
-			['subdomain.subdomain.google.com/?q1=v1&q2v2=#fragment', 'http://subdomain.subdomain.google.com/?q1=v1&q2v2=#fragment'],
+            // without scheme
+            ['google.com', 'http://google.com'],
+            ['google.com#fragment', 'http://google.com#fragment'],
+            ['google.com/#fragment', 'http://google.com/#fragment'],
+            ['google.com?q1=v1&q2v2', 'http://google.com?q1=v1&q2v2'],
+            ['google.com/?q1=v1&q2v2=#fragment', 'http://google.com/?q1=v1&q2v2=#fragment'],
+            ['subdomain.google.com', 'http://subdomain.google.com'],
+            ['subdomain.google.com#fragment', 'http://subdomain.google.com#fragment'],
+            ['subdomain.google.com/#fragment', 'http://subdomain.google.com/#fragment'],
+            ['subdomain.google.com?q1=v1&q2v2', 'http://subdomain.google.com?q1=v1&q2v2'],
+            ['subdomain.google.com/?q1=v1&q2v2=#fragment', 'http://subdomain.google.com/?q1=v1&q2v2=#fragment'],
+            ['subdomain.subdomain.google.com', 'http://subdomain.subdomain.google.com'],
+            ['subdomain.subdomain.google.com#fragment', 'http://subdomain.subdomain.google.com#fragment'],
+            ['subdomain.subdomain.google.com/#fragment', 'http://subdomain.subdomain.google.com/#fragment'],
+            ['subdomain.subdomain.google.com?q1=v1&q2v2', 'http://subdomain.subdomain.google.com?q1=v1&q2v2'],
+            ['subdomain.subdomain.google.com/?q1=v1&q2v2=#fragment', 'http://subdomain.subdomain.google.com/?q1=v1&q2v2=#fragment'],
 
-			// relative enconding
-			["/relative?v1=1<2", "/relative?v1=1%3C2"],
-			["/relative?1<2=v1", "/relative?1%3C2=v1"],
-			["http://goo>:gle.com?v1=12", ""], //Those chars at the domain level makes the url invalid, therefore the result should be empty.
-			["/relative/1<2/?te=12&b=", "/relative/1%3C2/?te=12&b="],
-			["/relative/1<2/?te=12&b=", "/relative/1%3C2/?te=12&b="],
+            // relative enconding
+            ["/relative?v1=1<2", "/relative?v1=1%3C2"],
+            ["/relative?1<2=v1", "/relative?1%3C2=v1"],
+            ["http://goo>:gle.com?v1=12", ""], //Those chars at the domain level makes the url invalid, therefore the result should be empty.
+            ["/relative/1<2/?te=12&b=", "/relative/1%3C2/?te=12&b="],
+            ["/relative/1<2/?te=12&b=", "/relative/1%3C2/?te=12&b="],
 
 
-			// XSS
+            // XSS
 
-			//Should escape the path
-			['http://example.com/"><script>alert("xss")</script>', 'http://example.com/%22%3E%3Cscript%3Ealert(%22xss%22)%3C/script%3E'],
-			["http://example.com/'><script>alert('xss')</script>", "http://example.com/%27%3E%3Cscript%3Ealert(%27xss%27)%3C/script%3E"],
+            //Should escape the path
+            ['http://example.com/"><script>alert("xss")</script>', 'http://example.com/%22%3E%3Cscript%3Ealert(%22xss%22)%3C/script%3E'],
+            ["http://example.com/'><script>alert('xss')</script>", "http://example.com/%27%3E%3Cscript%3Ealert(%27xss%27)%3C/script%3E"],
 
-			//Shouldn't accept javascript scheme
-			["javascript://test%0Aalert(321)", ''],
-			["javascript://alert(1)",'' ],
-			[" javascript://alert(1)", ''],
+            //Shouldn't accept javascript scheme
+            ["javascript://test%0Aalert(321)", ''],
+            ["javascript://alert(1)",'' ],
+            [" javascript://alert(1)", ''],
 
-			//Should escape the query string
-			["http://google.com?q1=\"<script>alert(1)</script>", "http://google.com?q1=%22%3Cscript%3Ealert(1)%3C/script%3E"],
-			["http://google.com/\"<script>alert(1)</script>/?q1", "http://google.com/%22%3Cscript%3Ealert(1)%3C/script%3E/?q1"],
-			["http://google.com/#\"<script>alert(1)</script>/?q1", "http://google.com/#%22%3Cscript%3Ealert(1)%3C/script%3E/?q1"],
+            //Should escape the query string
+            ["http://google.com?q1=\"<script>alert(1)</script>", "http://google.com?q1=%22%3Cscript%3Ealert(1)%3C/script%3E"],
+            ["http://google.com/\"<script>alert(1)</script>/?q1", "http://google.com/%22%3Cscript%3Ealert(1)%3C/script%3E/?q1"],
+            ["http://google.com/#\"<script>alert(1)</script>/?q1", "http://google.com/#%22%3Cscript%3Ealert(1)%3C/script%3E/?q1"],
 
-		];
-	}
+        ];
+    }
 }

--- a/tests/TestUrls.php
+++ b/tests/TestUrls.php
@@ -1,315 +1,291 @@
 <?php
 
 use PHPUnit\Framework\TestCase;
-use PHPUnit\Framework\AssertionFailedError;
 use eURL\Functions as url;
 
 require(__DIR__ . "/../vendor/autoload.php");
 
 final class ValidUrls extends TestCase
 {
-  public function testSimpleValidUrls(): void
-  {
-    $urls = [
-      "http://google.com",
-      "http://google.com#fragment",
-      "http://google.com/#fragment",
-      "http://google.com?q1=v1&q2v2",
-      "http://google.com?q1=v1&q2v2=",
-      "http://google.com/?q1=v1&q2v2",
-      "http://google.com/?q1=v1&q2v2=",
-      "https://google.com",
-      "https://google.com#fragment",
-      "https://google.com/#fragment",
-      "https://google.com?q1=v1&q2v2",
-      "https://google.com/?q1=v1&q2v2",
-      "http://google.com/page#fragment",
-      "http://google.com/page/#fragment",
-      "http://google.com?q1=v1&q2v2=#fragment",
-      "http://google.com/?q1=v1&q2v2=#fragment",
-      "http://google.com?q1=v1&q2v2#fragment",
-      "http://google.com/?q1=v1&q2v2#fragment",
-    ];
+	public function urlValidTest($url) {
 
-    $failures = [];
-    foreach ($urls as $url) {
-      try {
-        $this->assertEquals($url, url\e($url), "Failed at url $url");
-      } catch (\Exception $e) {
-        $failures[] = $url . " !== " . url\e($url);
-      }
-    }
-    if (!empty($failures)) {
-      throw new AssertionFailedError (
-        count($failures) . " assertions failed:\n\t" . implode("\n\t", $failures)
-      );
-    }
-  }
+		$this->assertSame($url, url\e($url));
 
-  public function testAddScheme(): void
-  {
-    $urls = [
-      "google.com",
-      "google.com#fragment",
-      "google.com/#fragment",
-      "google.com?q1=v1&q2v2",
-      "google.com/?q1=v1&q2v2=#fragment",
-      "subdomain.google.com",
-      "subdomain.google.com#fragment",
-      "subdomain.google.com/#fragment",
-      "subdomain.google.com?q1=v1&q2v2",
-      "subdomain.google.com/?q1=v1&q2v2=#fragment",
-      "subdomain.subdomain.google.com",
-      "subdomain.subdomain.google.com#fragment",
-      "subdomain.subdomain.google.com/#fragment",
-      "subdomain.subdomain.google.com?q1=v1&q2v2",
-      "subdomain.subdomain.google.com/?q1=v1&q2v2=#fragment",
-    ];
+	}
 
-    $failures = [];
-    foreach ($urls as $url) {
-      try {
-        $this->assertEquals("http://" . $url, url\e($url), "Failed at url $url");
-      } catch (\Exception $e) {
-        $failures[] = $url . " !== " . url\e($url);
-      }
-    }
-    if (!empty($failures)) {
-      throw new AssertionFailedError (
-        count($failures) . " assertions failed:\n\t" . implode("\n\t", $failures)
-      );
-    }
-  }
+    /**
+     * @dataProvider urlProvider
+     */
+	public function testValidSimpleUrls($url) {
 
-  public function testCopyAndPastedValidUrls(): void
-  {
-    $urls = [
-      "https://stackoverflow.com/questions/2681786/how-to-get-the-last-char-of-a-string-in-php",
-      "https://www.google.com/search?sxsrf=ACYBGNTJ6_E7vGHuXly-wapQEdX0-WR2eg%3A1571805081701&source=hp&ei=mdevXdCQKL685OUPwY-SqAs&q=test&btnK=Pesquisa+Google&oq=mail+url&gs_l=psy-ab.3..0i203l4j0i22i30l6.48741.49673..50184...0.0..0.98.570.8......0....1..gws-wiz.......35i39j0j0i67j0i10i203.wUQYlQVEwxU&ved=0ahUKEwiQwbGcxrHlAhU-HrkGHcGHBLUQ4dUDCAY&uact=5",
-      "https://www.google.com/search?q=test&sxsrf=ACYBGNSqRqbaCthrNVueRbiXQlYaA64AxQ1571808636488&source=lnms&tbm=isch&sa=X&ved=0ahUKEwjo6Lq707HlAhUfGbkGHaM1AacQ_AUIEigB&biw=1920&bih=878#imgrc=fZg5jDE2xDewFM",
-      "https://www.google.com/aclk?sa=L&ai=DChcSEwjA4ZLf07HlAhXECZEKHV5YAOMYABAAGgJjZQ&sig=AOD64_33mdKrF1qaxefqngRdnf_JGHc7Cw&q=&ved=2ahUKEwijgI3f07HlAhWKIbkGHdhuDsUQ0Qx6BAgNEAE&adurl=",
-      "https://www.facebook.com/photo.php?fbid=2272467782784102&set=a.378834528814113&type=3&theater",
-      "https://www.google.com/search?sxsrf=ACYBGNTJ6_E7vGHuXly-wapQEdX0-WR2eg%3A1571805081701&source=hp&ei=mdevXdCQKL685OUPwY-SqAs&q=t%C3%A9ste+busca+com+acento&btnK=Pesquisa+Google&oq=mail+url&gs_l=psy-ab.3..0i203l4j0i22i30l6.48741.49673..50184...0.0..0.98.570.8......0....1..gws-wiz.......35i39j0j0i67j0i10i203.wUQYlQVEwxU&ved=0ahUKEwiQwbGcxrHlAhU-HrkGHcGHBLUQ4dUDCAY&uact=5"
-    ];
+		$this->urlValidTest($url);
 
-    $failures = [];
-    foreach ($urls as $url) {
-      try {
-        $this->assertEquals($url, url\e($url), "Failed at url $url");
-      } catch (\Exception $e) {
-        $failures[] = $url . " !== " . url\e($url);
-      }
-    }
-    if (!empty($failures)) {
-      throw new AssertionFailedError (
-        count($failures) . " assertions failed:\n\t" . implode("\n\t", $failures)
-      );
-    }
-  }
+	}
 
-  public function testUrlEncoding(): void
-  {
-    $urls = [
-      [
-        "toTest" => "http://google.com?v1=1<2",
-        "expectedResult" => "http://google.com?v1=1%3C2"
-      ],
-      [
-        "toTest" => "http://google.com?1<2=v1",
-        "expectedResult" => "http://google.com?1%3C2=v1"
-      ],
-      [
-        "toTest" => "http://goo>:gle.com?v1=12",
-        "expectedResult" => "" //Those chars at the domain level makes the url invalid, therefore the result should be empty.
-      ],
-      [
-        "toTest" => "http://google.com/1<2/?te=12&b=",
-        "expectedResult" => "http://google.com/1%3C2/?te=12&b="
-      ],
-      [
-        "toTest" => "http://google.com/1<2/?te=12&b=",
-        "expectedResult" => "http://google.com/1%3C2/?te=12&b="
-      ]
-    ];
+	/**
+     * @codeCoverageIgnore
+     */
+    public function urlProvider()
+    {
+        return [
+			['http://google.com'],
+			['http://google.com#fragment'],
+			['http://google.com/#fragment'],
+			['http://google.com?q1=v1&q2v2'],
+			['http://google.com?q1=v1&q2v2='],
+			['http://google.com/?q1=v1&q2v2'],
+			['http://google.com/?q1=v1&q2v2='],
+			['https://google.com'],
+			['https://google.com#fragment'],
+			['https://google.com/#fragment'],
+			['https://google.com?q1=v1&q2v2'],
+			['https://google.com/?q1=v1&q2v2'],
+			['http://google.com/page#fragment'],
+			['http://google.com/page/#fragment'],
+			['http://google.com?q1=v1&q2v2=#fragment'],
+			['http://google.com/?q1=v1&q2v2=#fragment'],
+			['http://google.com?q1=v1&q2v2#fragment'],
+			['http://google.com/?q1=v1&q2v2#fragment'],
+		];
+	}
 
-    $failures = [];
-    foreach ($urls as $url) {
-      try {
-        $this->assertEquals(
-          $url['expectedResult'],
-          url\e($url['toTest']),
-          "Failed at url " . $url['toTest'] . " result: " . url\e($url['toTest']) . " expected: " . $url['expectedResult']
-        );
-      } catch (\Exception $e) {
-        $failures[] = $e->getMessage();
-      }
-    }
-    if (!empty($failures)) {
-      throw new AssertionFailedError (
-        count($failures) . " assertions failed:\n\t" . implode("\n\t", $failures)
-      );
-    }
-  }
+    /**
+     * @dataProvider urlSchemeProvider
+     */
+	public function testValidSchemeUrls($url) {
 
-  public function testUrlDoubleEncoding(): void
-  {
-    $urls = [
-      "http://google.com?v1=1%3C2",
-      "http://google.com?1%3C2=v1",
-      "http://google.com/1%3C2/?te=12&b=",
-    ];
+		$this->urlValidTest($url);
 
-    $failures = [];
-    foreach ($urls as $url) {
-      try {
-        $this->assertEquals($url, url\e($url), "Failed at url " . $url . " result: " . url\e($url));
-      } catch (\Exception $e) {
-        $failures[] = $e->getMessage();
-      }
-    }
-    if (!empty($failures)) {
-      throw new AssertionFailedError (
-        count($failures) . " assertions failed:\n\t" . implode("\n\t", $failures)
-      );
-    }
-  }
+	}
 
-  public function testXSSAttempts(): void
-  {
-    $urls = [
-      [
-        "toTest" => 'http://example.com/"><script>alert("xss")</script>',
-        "expectedResult" => 'http://example.com/'.url\encode('"><script>alert("xss")</script>') //Should escape the path
-      ],
-      [
-        "toTest" => "http://example.com/'><script>alert('xss')</script>",
-        "expectedResult" => "http://example.com/".url\encode("'><script>alert('xss')</script>") //Should escape the path
-      ],
-      [
-        "toTest" => "javascript://test%0Aalert(321)",
-        "expectedResult" => "" //Shouldn't accept javascript scheme
-      ],
-      [
-        "toTest" => "javascript://alert(1)",
-        "expectedResult" => ""//Shouldn't accept javascript scheme
-      ],
-      [
-        "toTest" => " javascript://alert(1)",
-        "expectedResult" => ""//Shouldn't accept javascript scheme
-      ],
-      [
-        "toTest" => "http://google.com?q1=\"<script>alert(1)</script>",
-        "expectedResult" => "http://google.com?q1=".url\encode("\"<script>alert(1)</script>"), //Should escape the query string
-      ],
-      [
-        "toTest" => "http://google.com/\"<script>alert(1)</script>/?q1",
-        "expectedResult" => "http://google.com/".url\encode("\"<script>alert(1)</script>")."/?q1",
-      ],
-      [
-        "toTest" => "http://google.com/#\"<script>alert(1)</script>/?q1",
-        "expectedResult" => "http://google.com/#".url\encode("\"<script>alert(1)</script>")."/?q1",
-      ],
-    ];
+	/**
+     * @codeCoverageIgnore
+     */
+    public function urlSchemeProvider()
+    {
+		return [
+			['google.com'],
+			['google.com#fragment'],
+			['google.com/#fragment'],
+			['google.com?q1=v1&q2v2'],
+			['google.com/?q1=v1&q2v2=#fragment'],
+			['subdomain.google.com'],
+			['subdomain.google.com#fragment'],
+			['subdomain.google.com/#fragment'],
+			['subdomain.google.com?q1=v1&q2v2'],
+			['subdomain.google.com/?q1=v1&q2v2=#fragment'],
+			['subdomain.subdomain.google.com'],
+			['subdomain.subdomain.google.com#fragment'],
+			['subdomain.subdomain.google.com/#fragment'],
+			['subdomain.subdomain.google.com?q1=v1&q2v2'],
+			['subdomain.subdomain.google.com/?q1=v1&q2v2=#fragment'],
+		];
+	}
 
-    $failures = [];
-    foreach ($urls as $url) {
-      try {
-        $this->assertEquals(
-          $url['expectedResult'],
-          url\e($url['toTest']),
-          "Failed at url " . $url['toTest'] . " result: " . url\e($url['toTest']) . " expected: " . $url['expectedResult']
-        );
-      } catch (\Exception $e) {
-        $failures[] = $url['expectedResult'] . " !== " . url\e($url['toTest']);
-      }
-    }
-    if (!empty($failures)) {
-      throw new AssertionFailedError (
-        count($failures) . " assertions failed:\n\t" . implode("\n\t", $failures)
-      );
-    }
-  }
+    /**
+     * @dataProvider copyAndPastedUrlsProvider
+     */
+	public function testCopyAndPastedUrlsTest($url) {
 
-  public function testRelativeUrls(): void
-  {
-    $urls = [
-      "/relative",
-      "/relative/test/",
-      "/relative#fragment",
-      "/relative/#fragment",
-      "/relative?q1=v1&q2v2",
-      "/relative?q1=v1&q2v2=",
-      "/relative/?q1=v1&q2v2",
-      "/relative/?q1=v1&q2v2=",
-      "/relative/page#fragment",
-      "/relative/page/#fragment",
-      "/relative?q1=v1&q2v2=#fragment",
-      "/relative/?q1=v1&q2v2=#fragment",
-      "/relative?q1=v1&q2v2#fragment",
-      "/relative/?q1=v1&q2v2#fragment",
-      "relative",
-      "relative/test/",
-      "relative#fragment",
-      "relative/#fragment",
-      "relative?q1=v1&q2v2",
-      "relative?q1=v1&q2v2=",
-    ];
-    $failures = [];
-    foreach ($urls as $url) {
-      try {
-        $this->assertEquals($url, url\e($url), "Failed at url $url");
-      } catch (\Exception $e) {
-        $failures[] = $url . " !== " . url\e($url);
-      }
-    }
-    if (!empty($failures)) {
-      throw new AssertionFailedError (
-        count($failures) . " assertions failed:\n\t" . implode("\n\t", $failures)
-      );
-    }
-  }
+		$this->urlValidTest($url);
 
-  public function testRelativeUrlsEncoding(): void
-  {
-    $urls = [
-      [
-        "toTest" => "/relative?v1=1<2",
-        "expectedResult" => "/relative?v1=1%3C2"
-      ],
-      [
-        "toTest" => "/relative?1<2=v1",
-        "expectedResult" => "/relative?1%3C2=v1"
-      ],
-      [
-        "toTest" => "http://goo>:gle.com?v1=12",
-        "expectedResult" => "" //Those chars at the domain level makes the url invalid, therefore the result should be empty.
-      ],
-      [
-        "toTest" => "/relative/1<2/?te=12&b=",
-        "expectedResult" => "/relative/1%3C2/?te=12&b="
-      ],
-      [
-        "toTest" => "/relative/1<2/?te=12&b=",
-        "expectedResult" => "/relative/1%3C2/?te=12&b="
-      ]
-    ];
+	}
 
-    $failures = [];
-    foreach ($urls as $url) {
-      try {
-        $this->assertEquals(
-          $url['expectedResult'],
-          url\e($url['toTest'] ),
-          "Failed at url " . $url['toTest'] . " result: " . url\e($url['toTest']) . " expected: " . $url['expectedResult']
-        );
-      } catch (\Exception $e) {
-        $failures[] = $e->getMessage();
-      }
-    }
-    if (!empty($failures)) {
-      throw new AssertionFailedError (
-        count($failures) . " assertions failed:\n\t" . implode("\n\t", $failures)
-      );
-    }
-  }
+	/**
+     * @codeCoverageIgnore
+     */
+    public function copyAndPastedUrlsProvider()
+    {
+		return [
+			['https://stackoverflow.com/questions/2681786/how-to-get-the-last-char-of-a-string-in-php'],
+			['https://www.google.com/search?sxsrf=ACYBGNTJ6_E7vGHuXly-wapQEdX0-WR2eg%3A1571805081701&source=hp&ei=mdevXdCQKL685OUPwY-SqAs&q=test&btnK=Pesquisa+Google&oq=mail+url&gs_l=psy-ab.3..0i203l4j0i22i30l6.48741.49673..50184...0.0..0.98.570.8......0....1..gws-wiz.......35i39j0j0i67j0i10i203.wUQYlQVEwxU&ved=0ahUKEwiQwbGcxrHlAhU-HrkGHcGHBLUQ4dUDCAY&uact=5'],
+			['https://www.google.com/search?q=test&sxsrf=ACYBGNSqRqbaCthrNVueRbiXQlYaA64AxQ1571808636488&source=lnms&tbm=isch&sa=X&ved=0ahUKEwjo6Lq707HlAhUfGbkGHaM1AacQ_AUIEigB&biw=1920&bih=878#imgrc=fZg5jDE2xDewFM'],
+			['https://www.google.com/aclk?sa=L&ai=DChcSEwjA4ZLf07HlAhXECZEKHV5YAOMYABAAGgJjZQ&sig=AOD64_33mdKrF1qaxefqngRdnf_JGHc7Cw&q=&ved=2ahUKEwijgI3f07HlAhWKIbkGHdhuDsUQ0Qx6BAgNEAE&adurl='],
+			['https://www.facebook.com/photo.php?fbid=2272467782784102&set=a.378834528814113&type=3&theater'],
+			['https://www.google.com/search?sxsrf=ACYBGNTJ6_E7vGHuXly-wapQEdX0-WR2eg%3A1571805081701&source=hp&ei=mdevXdCQKL685OUPwY-SqAs&q=t%C3%A9ste+busca+com+acento&btnK=Pesquisa+Google&oq=mail+url&gs_l=psy-ab.3..0i203l4j0i22i30l6.48741.49673..50184...0.0..0.98.570.8......0....1..gws-wiz.......35i39j0j0i67j0i10i203.wUQYlQVEwxU&ved=0ahUKEwiQwbGcxrHlAhU-HrkGHcGHBLUQ4dUDCAY&uact=5'],
+		];
+	}
+
+    /**
+     * @dataProvider urlEncodingProvider
+     */
+	public function testUrlEncoding($url, $expected) {
+
+		$this->assertSame($expected, url\e($url));
+
+	}
+
+	/**
+     * @codeCoverageIgnore
+     */
+    public function urlEncodingProvider()
+    {
+		return [
+
+			["http://google.com?v1=1<2", "http://google.com?v1=1%3C2"],
+			["http://google.com?1<2=v1", "http://google.com?1%3C2=v1"],
+
+			//Those chars at the domain level makes the url invalid, therefore the result should be empty.
+			["http://goo>:gle.com?v1=12", ""],
+
+			["http://google.com/1<2/?te=12&b=", "http://google.com/1%3C2/?te=12&b="],
+			["http://google.com/1<2/?te=12&b=", "http://google.com/1%3C2/?te=12&b="],
+
+		];
+	}
+
+    /**
+     * @dataProvider urlDoubleEncodingProvider
+     */
+	public function testUrlDoubleEncoding($url) {
+
+		$this->urlValidTest($url);
+
+	}
+
+	/**
+     * @codeCoverageIgnore
+     */
+    public function urlDoubleEncodingProvider()
+    {
+		return [
+			["http://google.com?v1=1%3C2"],
+			["http://google.com?1%3C2=v1"],
+			["http://google.com/1%3C2/?te=12&b="],
+		];
+	}
+
+    /**
+     * @dataProvider xssAttemptsProvider
+     */
+	public function testXssAttempts($url, $expected) {
+
+		$this->assertSame($expected, url\e($url));
+
+	}
+
+	/**
+     * @codeCoverageIgnore
+     */
+    public function xssAttemptsProvider()
+    {
+		return [
+			[
+				'http://example.com/"><script>alert("xss")</script>',
+				'http://example.com/%22%3E%3Cscript%3Ealert(%22xss%22)%3C/script%3E' //Should escape the path
+			],
+			[
+				"http://example.com/'><script>alert('xss')</script>",
+				"http://example.com/%27%3E%3Cscript%3Ealert(%27xss%27)%3C/script%3E" //Should escape the path
+			],
+			[
+				"javascript://test%0Aalert(321)",
+				'' //Shouldn't accept javascript scheme
+			],
+			[
+				"javascript://alert(1)",
+				'' //Shouldn't accept javascript scheme
+			],
+			[
+				" javascript://alert(1)",
+				'' //Shouldn't accept javascript scheme
+			],
+			[
+				"http://google.com?q1=\"<script>alert(1)</script>",
+				"http://google.com?q1=%22%3Cscript%3Ealert(1)%3C/script%3E", //Should escape the query string
+			],
+			[
+				"http://google.com/\"<script>alert(1)</script>/?q1",
+				"http://google.com/%22%3Cscript%3Ealert(1)%3C/script%3E/?q1",
+			],
+			[
+				"http://google.com/#\"<script>alert(1)</script>/?q1",
+				"http://google.com/#%22%3Cscript%3Ealert(1)%3C/script%3E/?q1",
+			],
+		];
+	}
+
+	/*
+	public function testRelativeUrls(): void
+	{
+	$urls = [
+		"/relative",
+		"/relative/test/",
+		"/relative#fragment",
+		"/relative/#fragment",
+		"/relative?q1=v1&q2v2",
+		"/relative?q1=v1&q2v2=",
+		"/relative/?q1=v1&q2v2",
+		"/relative/?q1=v1&q2v2=",
+		"/relative/page#fragment",
+		"/relative/page/#fragment",
+		"/relative?q1=v1&q2v2=#fragment",
+		"/relative/?q1=v1&q2v2=#fragment",
+		"/relative?q1=v1&q2v2#fragment",
+		"/relative/?q1=v1&q2v2#fragment",
+		"relative",
+		"relative/test/",
+		"relative#fragment",
+		"relative/#fragment",
+		"relative?q1=v1&q2v2",
+		"relative?q1=v1&q2v2=",
+	];
+	$failures = [];
+	foreach ($urls as $url) {
+		try {
+		$this->assertEquals($url, url\e($url), "Failed at url $url");
+		} catch (\Exception $e) {
+		$failures[] = $url . " !== " . url\e($url);
+		}
+	}
+	if (!empty($failures)) {
+		throw new AssertionFailedError (
+		count($failures) . " assertions failed:\n\t" . implode("\n\t", $failures)
+		);
+	}
+	}
+
+	public function testRelativeUrlsEncoding(): void
+	{
+	$urls = [
+		[
+		"toTest" => "/relative?v1=1<2",
+		"expectedResult" => "/relative?v1=1%3C2"
+		],
+		[
+		"toTest" => "/relative?1<2=v1",
+		"expectedResult" => "/relative?1%3C2=v1"
+		],
+		[
+		"toTest" => "http://goo>:gle.com?v1=12",
+		"expectedResult" => "" //Those chars at the domain level makes the url invalid, therefore the result should be empty.
+		],
+		[
+		"toTest" => "/relative/1<2/?te=12&b=",
+		"expectedResult" => "/relative/1%3C2/?te=12&b="
+		],
+		[
+		"toTest" => "/relative/1<2/?te=12&b=",
+		"expectedResult" => "/relative/1%3C2/?te=12&b="
+		]
+	];
+
+	$failures = [];
+	foreach ($urls as $url) {
+		try {
+		$this->assertEquals(
+			$url['expectedResult'],
+			url\e($url['htoTest'] ),
+			"Failed at url " . $url['htoTest'] . " result: " . url\e($url['htoTest']) . " expected: " . $url['expectedResult']
+		);
+		} catch (\Exception $e) {
+		$failures[] = $e->getMessage();
+		}
+	}
+	if (!empty($failures)) {
+		throw new AssertionFailedError (
+		count($failures) . " assertions failed:\n\t" . implode("\n\t", $failures)
+		);
+	}
+	*/
 }

--- a/tests/TestUrls.php
+++ b/tests/TestUrls.php
@@ -10,9 +10,7 @@ final class ValidUrls extends TestCase
      */
 	public function testValidUrl($url): void
 	{
-
 		$this->assertSame($url, url\e($url));
-
 	}
 
     /**
@@ -20,9 +18,7 @@ final class ValidUrls extends TestCase
      */
 	public function testInvalidUrl($url, $expected): void
 	{
-
 		$this->assertSame($expected, url\e($url));
-
 	}
 
 	/**


### PR DESCRIPTION
Unit tests should be simple and easy to write. The new tests use only 2 data providers containing a list of valid and invalid urls, making it easy to add new urls to be tested. Every domain from the old test suite was added to the correct data provider and the phpunit's output now shows the correct number of tests and assertions. The output itself already warns about failed tests showing what was tested and what was expected, so there is no need to implement those things in the test code.

Added: phpunit.xml containing tests configs, including coverage reports. Now we can run tests using just the command `vendor/bin/phpunit`

Updated: .gitignore to ignore test reports

Fixes #3 