### PR TITLE
9 - Changes the way that we were currently encoding the parameters to…

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 This package aims to deliver a good way to easily escape URLs that will be used on HTML attributes.
 
+You should not use this package to generate URLs, ideally the URLs received here would already be escaped and safe. 
+This project doesn't aim to encode your URL and make it browser compatible. 
+ 
+## Goals:
+
+- Prevent XSS attacks
+- Avoid at maximum changing and therefore possibly break the URLs
 
 ## Usage:
 ```php

--- a/src/Functions.php
+++ b/src/Functions.php
@@ -16,18 +16,18 @@ function e(string $url, string $defaultScheme = 'http://', array $allowedSchemes
     if ($parsedUrl === false) return '';
 
     $parsedUrlSkeleton = array(
-        'scheme'   => '',
-        'host'     => '',
-        'path'     => '',
-        'query'    => '',
+        'scheme' => '',
+        'host' => '',
+        'path' => '',
+        'query' => '',
         'fragment' => '',
     );
 
     $parsedUrl = array_merge($parsedUrlSkeleton, $parsedUrl);
 
-    $parsedUrl['scheme']   = encode($parsedUrl['scheme']);
-    $parsedUrl['host']     = encode($parsedUrl['host']);
-    $parsedUrl['path']     = encode($parsedUrl['path']);
+    $parsedUrl['scheme'] = encode($parsedUrl['scheme']);
+    $parsedUrl['host'] = encode($parsedUrl['host']);
+    $parsedUrl['path'] = encode($parsedUrl['path']);
     $parsedUrl['fragment'] = encode($parsedUrl['fragment']);
 
     if ($parsedUrl['scheme'] !== '' && !in_array($parsedUrl['scheme'], $allowedSchemes)) return '';
@@ -39,26 +39,23 @@ function e(string $url, string $defaultScheme = 'http://', array $allowedSchemes
 
 /**
  *
- * @param array $params
+ * @param string $queryString
  * @return string
  */
 function encodeQueryString(string $queryString): string
 {
-    if ($queryString) {
-        $queryHasTrailingEqual = substr($queryString, -1) === "=";
+    if ($queryString !== '') {
+        $queryHasTrailingEqual = substr($queryString, -1) === '=';
 
-        $params = explode("&", $queryString);
-        $result = "";
+        $params = explode('&', $queryString);
+        $result = [];
         foreach ($params as $k => $param) {
-            if ($k > 0) {
-                $result .= "&";
-            }
             $paramParts = explode('=', $param, 2);
             $paramName = $paramParts[0];
-            $paramValue = (isset($paramParts[1])) ? $paramParts[1] : "";
-
-            $result .= encode($paramName) . "=" . encode($paramValue);
+            $paramValue = (array_key_exists(1,$paramParts)) ? $paramParts[1] : '';
+            $result[] = encode($paramName) . '=' . encode($paramValue);
         }
+        $result = implode('&', $result);
 
         if ($queryHasTrailingEqual === false) {
             $result = rtrim($result, '=');
@@ -77,8 +74,8 @@ function encodeQueryString(string $queryString): string
  */
 function build(array $url, $defaultScheme = 'http://'): string
 {
-    $query    = ($url['query']     !== '') ? '?' . $url['query']    : '';
-    $fragment = ($url['fragment']  !== '') ? '#' . $url['fragment'] : '';
+    $query = ($url['query'] !== '') ? '?' . $url['query'] : '';
+    $fragment = ($url['fragment'] !== '') ? '#' . $url['fragment'] : '';
 
     $result = $url['host'] . $url['path'] . $query . $fragment;
 
@@ -106,7 +103,7 @@ function build(array $url, $defaultScheme = 'http://'): string
  */
 function encode(string $str): string
 {
-    $chars = array("\n", "'", "\"", "<", ">","[","]","{","}");
+    $chars = array("\n", "'", "\"", "<", ">", "[", "]", "{", "}");
     $replacements = array_map("urlencode", $chars);
     return str_ireplace($chars, $replacements, $str);
 }

--- a/tests/TestUrls.php
+++ b/tests/TestUrls.php
@@ -55,11 +55,15 @@ final class ValidUrls extends TestCase
             ['https://www.google.com/aclk?sa=L&ai=DChcSEwjA4ZLf07HlAhXECZEKHV5YAOMYABAAGgJjZQ&sig=AOD64_33mdKrF1qaxefqngRdnf_JGHc7Cw&q=&ved=2ahUKEwijgI3f07HlAhWKIbkGHdhuDsUQ0Qx6BAgNEAE&adurl='],
             ['https://www.facebook.com/photo.php?fbid=2272467782784102&set=a.378834528814113&type=3&theater'],
             ['https://www.google.com/search?sxsrf=ACYBGNTJ6_E7vGHuXly-wapQEdX0-WR2eg%3A1571805081701&source=hp&ei=mdevXdCQKL685OUPwY-SqAs&q=t%C3%A9ste+busca+com+acento&btnK=Pesquisa+Google&oq=mail+url&gs_l=psy-ab.3..0i203l4j0i22i30l6.48741.49673..50184...0.0..0.98.570.8......0....1..gws-wiz.......35i39j0j0i67j0i10i203.wUQYlQVEwxU&ved=0ahUKEwiQwbGcxrHlAhU-HrkGHcGHBLUQ4dUDCAY&uact=5'],
+            ['https://www.google.com/search?sxsrf=ACYBGNQQyyr9xMHuMngwJFd2Yh5Ek-_OiA%3A1574423217487&source=hp&ei=scrXXcbMGpHW5OUP0a2skAI&q=test%2Ftest&btnK=Pesquisa+Google&oq=cronometro&gs_l=psy-ab.3..0i203l5j0i10i203j0i203j0j0i203j0.481.1662..1773...1.0..1.326.1078.5j3j0j1......0....1..gws-wiz.......35i39j35i39i19.Mfc7-u3RE9Y&ved=0ahUKEwiG6efE3_3lAhURK7kGHdEWCyIQ4dUDCAY&uact=5'],
         
             // double enconding
             ["http://google.com?v1=1%3C2"],
             ["http://google.com?1%3C2=v1"],
             ["http://google.com/1%3C2/?te=12&b="],
+
+            // unecessary decoding
+            ["http://domain.com/?key=test%2Ftest"],
 
             // relative
             ['/relative'],
@@ -123,8 +127,6 @@ final class ValidUrls extends TestCase
             ["/relative/1<2/?te=12&b=", "/relative/1%3C2/?te=12&b="],
             ["/relative/1<2/?te=12&b=", "/relative/1%3C2/?te=12&b="],
 
-
-            // XSS
 
             //Should escape the path
             ['http://example.com/"><script>alert("xss")</script>', 'http://example.com/%22%3E%3Cscript%3Ealert(%22xss%22)%3C/script%3E'],


### PR DESCRIPTION
FIXES #9 

The bug was caused by both the default `parse_str` function from PHP which automatically decodes the query string values and our old implementation of the `encode()` function. I've tweaked the implementation so we don't need PHP's `parse_str` and changed our `encode()` function to work as a blacklisting scheme.

I updated the README to clearly state the goals of this project and avoiding confusion. 

And finally, I added an extra test case that would fail on Master due to the bug being fixed here.