### PR TITLE
Updates PHP version; adds Docker files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ package-lock.json
 yarn-error.log
 yarn.lock
 /tests/_reports
+/.phpunit.result.cache

--- a/Dockerfile_php81
+++ b/Dockerfile_php81
@@ -1,0 +1,3 @@
+FROM php:8.1.5-cli-alpine
+
+RUN curl -sS https://getcomposer.org/installer | php && mv composer.phar /usr/local/bin/composer

--- a/README.md
+++ b/README.md
@@ -27,3 +27,10 @@ To run the tests you must install the composer dependencies and then run:
 ```
 vendor/bin/phpunit tests/TestUrls.php
 ```
+
+## Running tests with Docker:
+
+* Run container: `docker-compose -f docker-compose_php81.yml run php sh`
+* Change directory: `cd /var/www/html`
+* Install dependencies: `composer install`
+* Run tests: `vendor/bin/phpunit tests/TestUrls.php`

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   ],
   "require": {
-    "php": "7.*"
+    "php": ">=7.0"
   },
   "require-dev": {
     "phpunit/phpunit": "7.*"

--- a/docker-compose_php81.yml
+++ b/docker-compose_php81.yml
@@ -1,0 +1,9 @@
+version: "3.3"
+
+services:
+  php:
+    build:
+      context: .
+      dockerfile: Dockerfile_php81
+    volumes:
+      - ./:/var/www/html

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,10 +1,10 @@
+<?xml version="1.0"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.3/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
     backupGlobals="true"
     backupStaticAttributes="false"
     bootstrap="vendor/autoload.php"
-    cacheTokens="false"
     colors="true"
     convertErrorsToExceptions="true"
     convertNoticesToExceptions="true"
@@ -20,20 +20,22 @@
     timeoutForMediumTests="10"
     timeoutForLargeTests="60"
     verbose="false">
+    <coverage>
+        <include>
+            <directory suffix=".php">./src</directory>
+            <directory suffix=".php">./tests</directory>
+        </include>
+        <report>
+            <clover outputFile="tests/_reports/logs/clover.xml"/>
+            <html outputDirectory="tests/_reports/coverage" lowUpperBound="35" highLowerBound="70"/>
+        </report>
+    </coverage>
     <testsuites>
         <testsuite name="Test Suite">
             <directory suffix=".php">./tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-            <directory suffix=".php">./tests</directory>
-        </whitelist>
-    </filter>
     <logging>
-        <log type="coverage-clover" target="tests/_reports/logs/clover.xml"/>
-        <log type="coverage-html" target="tests/_reports/coverage" lowUpperBound="35" highLowerBound="70" />
-        <log type="testdox-text" target="tests/_reports/testdox/executed.txt"/>
+        <testdoxText outputFile="tests/_reports/testdox/executed.txt"/>
     </logging>
 </phpunit>

--- a/tests/TestUrls.php
+++ b/tests/TestUrls.php
@@ -3,7 +3,7 @@
 use PHPUnit\Framework\TestCase;
 use eURL\Functions as url;
 
-final class ValidUrls extends TestCase
+final class TestUrls extends TestCase
 {
     /**
      * @dataProvider validUrlProvider
@@ -47,7 +47,7 @@ final class ValidUrls extends TestCase
             ['http://google.com/?q1=v1&q2v2=#fragment'],
             ['http://google.com?q1=v1&q2v2#fragment'],
             ['http://google.com/?q1=v1&q2v2#fragment'],
-            
+
             // copy and pasted
             ['https://stackoverflow.com/questions/2681786/how-to-get-the-last-char-of-a-string-in-php'],
             ['https://www.google.com/search?sxsrf=ACYBGNTJ6_E7vGHuXly-wapQEdX0-WR2eg%3A1571805081701&source=hp&ei=mdevXdCQKL685OUPwY-SqAs&q=test&btnK=Pesquisa+Google&oq=mail+url&gs_l=psy-ab.3..0i203l4j0i22i30l6.48741.49673..50184...0.0..0.98.570.8......0....1..gws-wiz.......35i39j0j0i67j0i10i203.wUQYlQVEwxU&ved=0ahUKEwiQwbGcxrHlAhU-HrkGHcGHBLUQ4dUDCAY&uact=5'],
@@ -56,7 +56,7 @@ final class ValidUrls extends TestCase
             ['https://www.facebook.com/photo.php?fbid=2272467782784102&set=a.378834528814113&type=3&theater'],
             ['https://www.google.com/search?sxsrf=ACYBGNTJ6_E7vGHuXly-wapQEdX0-WR2eg%3A1571805081701&source=hp&ei=mdevXdCQKL685OUPwY-SqAs&q=t%C3%A9ste+busca+com+acento&btnK=Pesquisa+Google&oq=mail+url&gs_l=psy-ab.3..0i203l4j0i22i30l6.48741.49673..50184...0.0..0.98.570.8......0....1..gws-wiz.......35i39j0j0i67j0i10i203.wUQYlQVEwxU&ved=0ahUKEwiQwbGcxrHlAhU-HrkGHcGHBLUQ4dUDCAY&uact=5'],
             ['https://www.google.com/search?sxsrf=ACYBGNQQyyr9xMHuMngwJFd2Yh5Ek-_OiA%3A1574423217487&source=hp&ei=scrXXcbMGpHW5OUP0a2skAI&q=test%2Ftest&btnK=Pesquisa+Google&oq=cronometro&gs_l=psy-ab.3..0i203l5j0i10i203j0i203j0j0i203j0.481.1662..1773...1.0..1.326.1078.5j3j0j1......0....1..gws-wiz.......35i39j35i39i19.Mfc7-u3RE9Y&ved=0ahUKEwiG6efE3_3lAhURK7kGHdEWCyIQ4dUDCAY&uact=5'],
-        
+
             // double enconding
             ["http://google.com?v1=1%3C2"],
             ["http://google.com?1%3C2=v1"],
@@ -86,7 +86,7 @@ final class ValidUrls extends TestCase
             ['relative/#fragment'],
             ['relative?q1=v1&q2v2'],
             ['relative?q1=v1&q2v2='],
-            
+
         ];
     }
 


### PR DESCRIPTION
* Changed the required PHP version from `7.*` to `>=7.0`.
* Added Docker files for easier testing with different PHP versions; added configuration for PHP 8.1.
* Changed the name of the class in `tests/TestUrls.php` to match the file name because PHPUnit didn't find the class.
* Updated `phpunit.xml`. PHPUnit said the file had an old configuration and suggested to run a command to update the file automatically.
